### PR TITLE
Configuration finale pour déploiement sur trackdechets.beta.gouv.fr

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,10 +7,9 @@ module.exports = {
       "Trackdéchets a vocation à simplifier la gestion de vos déchets dangereux au quotidien : 0 papier, traçabilité en temps réel, informations regroupées sur un outil unique, vérification des prestataires.",
     url:
       process.env.NODE_ENV === "production"
-        ? "https://mtes-mct.github.io/trackdechets-website/"
+        ? "https://trackdechets.beta.gouv.fr/"
         : "http://localhost:8000",
   },
-  pathPrefix: "/trackdechets-website",
   plugins: [
     "gatsby-plugin-react-helmet",
     "gatsby-plugin-styled-components",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "gatsby build --prefix-paths",
+    "build": "gatsby build",
     "start": "gatsby develop"
   },
   "dependencies": {

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { PageProps, withPrefix } from "gatsby";
 import { NotFound } from "../components/pages";
 
-const APP_ORIGIN = "https://trackdechets.beta.gouv.fr";
+const APP_ORIGIN = "https://app.trackdechets.beta.gouv.fr";
 const APP_PATHS = [
   "/login",
   "/signup",

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+trackdechets.beta.gouv.fr


### PR DESCRIPTION
Cette PR implémente les derniers changements qui basculent le déploiement de la page GitHub de https://mtes-mct.github.io/trackdechets-website/ à https://trackdechets.beta.gouv.fr

- [x] Ajouter le CNAME
- [x] Mettre à jour `siteMetadata.url` dans `gatsby-config.js`
- [x] Mettre à jour `APP_ORIGIN` dans `src/pages/404.tsx`
- [x] Supprimer le paramètre `pathPrefix` dans `gatsby-config.js`
- [x] Supprimer le flag `--prefix-paths` du script build

À faire au moment du déploiement :

- [ ] Créer un record `A` pour le domaine `trackdechets.beta.gouv.fr` qui pointe sur les IPs de GitHub :
  ```
  185.199.108.153
  185.199.109.153
  185.199.110.153
  185.199.111.153
  ```

  Cf la [documentation](https://docs.github.com/en/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain) pour plus de détails.
- [ ] Créer un record `A` pour le domaine `app.trackdechets.beta.gouv.fr` qui pointe sur l'IP du serveur de l'application.