### PR TITLE
Fixes the wrong path of the plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -46,7 +46,10 @@ module.exports = {
       resolve: `gatsby-plugin-plausible`,
       options: {
         domain: process.env.PLAUSIBLE_DOMAIN,
-        customDomain: `plausible.trackdechets.beta.gouv.fr`,
+        // Currently when using a custom domain with self-hosted plausible, the script
+        // path will incorrectly point to index.js. Here we force the correct path...
+        // https://github.com/pixelplicity/gatsby-plugin-plausible/issues/49
+        customDomain: `plausible.trackdechets.beta.gouv.fr/js/script.js?original=`,
       },
     },
   ],


### PR DESCRIPTION
On ajoute l'URL complète et on skip ce que le plugin rajoute pour pouvoir utiliser les analytics...
Cf. les nombreuses discussions sur le Github https://github.com/pixelplicity/gatsby-plugin-plausible/issues/49